### PR TITLE
Directly call CODEOWNERS validator instead of through a shared workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,11 @@ name: CI
 on: push
 
 jobs:
-  shared-workflow:
-    uses: scribd/github-actions-shared-workflows/.github/workflows/shared-workflow.yml@main
-    secrets:
-      github_access_token: ${{ secrets.SCRIBD_GITHUB_GENERIC_TOKEN }}
+  codeowners:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: GitHub CODEOWNERS Validator
+        uses: mszostok/codeowners-validator@v0.7.1
+        with:
+          checks: "files,duppatterns,syntax"


### PR DESCRIPTION
Follow-up to https://github.com/scribd/terraform-s3-rbac/pull/15

We cannot use the shared workflow since this is a public repository therefore we just call the underlying codeowner validator directly.

Confirmed the new check is passing: https://github.com/scribd/terraform-s3-rbac/runs/5295773281?check_suite_focus=true