### PR TITLE
[CODE-863] Define the default server-side bucket encryption

### DIFF
--- a/s3_bucket.tf
+++ b/s3_bucket.tf
@@ -34,6 +34,14 @@ resource "aws_s3_bucket" "s3_buckets" {
       max_age_seconds = cors_rule.value.max_age_seconds
     }
   }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 # Make sure no object could ever be public


### PR DESCRIPTION
## Description

The PR defines the default server-side bucket encryption with the default KMS encryption key and SSE algorithm `AES256`. Otherwise, the root modules, which use this module, want to remove the server-side encryption for the S3 buckets created by this module:
```hcl
      - server_side_encryption_configuration {
          - rule {
              - bucket_key_enabled = false -> null
              - apply_server_side_encryption_by_default {
                  - sse_algorithm = "AES256" -> null
                }
            }
        }
```

## Checklist:

- Prefixed the PR title with the JIRA ticket code if available.<!-- e.g. `[JIR-XXX] Add <XYZ> repository` -->
- Checked the guidelines for contribution if available.
- Performed simple, atomic commits with clear commit messages.
- Include any relevant context or links if helpful.
- Updated the `README.md` as necessary.

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [CODE-863](https://scribdjira.atlassian.net/browse/CODE-863)


[CODE-863]: https://scribdjira.atlassian.net/browse/CODE-863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ